### PR TITLE
docs: fix typo in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ the MoonBit language.
 ```lua
 {
   'tonyfettes/moonbit.nvim',
-  ft = { 'moonbit' }
+  ft = { 'moonbit' },
   opts = {},
 }
 ```


### PR DESCRIPTION
Closes #1 with the help of 9db2cbb1b6e844026c255de38a4d00c89294a9e5.