### PR TITLE
feat: add the ability to configure and disable the language server

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,17 @@ the MoonBit language.
 {
   'tonyfettes/moonbit.nvim',
   ft = { 'moonbit' },
-  opts = {},
+  opts = {
+    -- optionally disable the treesitter integration
+    treesitter =  { enabled = true }
+    -- configure the language server integration
+    -- set `lsp = false` to disable the language server integration
+    lsp = {
+      -- provide an `on_attach` function to run when the language server starts
+      on_attach = function(client, bufnr) end
+      -- provide client capabilities to pass to the language server
+      capabilities = vim.lsp.protocol.make_client_capabilities(),
+    }
+  },
 }
 ```

--- a/lua/moonbit.lua
+++ b/lua/moonbit.lua
@@ -7,15 +7,18 @@ return {
       require 'moonbit.treesitter'.setup(treesitter_opts)
     end
 
-    vim.api.nvim_create_autocmd('FileType', {
-      pattern = 'moonbit',
-      callback = function(ev)
-        vim.lsp.start({
-          name = 'moonbit-lsp',
-          cmd = { 'moonbit-lsp' },
-          root_dir = vim.fs.root(ev.buf, { 'moon.mod.json' })
-        })
-      end
-    })
+    if opts.lsp ~= false then
+      vim.api.nvim_create_autocmd('FileType', {
+        pattern = 'moonbit',
+        group = vim.api.nvim_create_augroup("moonbit_lsp", { clear = true }),
+        callback = function(ev)
+          vim.lsp.start(vim.tbl_deep_extend("keep", opts.lsp or {}, {
+            name = 'moonbit-lsp',
+            cmd = { 'moonbit-lsp' },
+            root_dir = vim.fs.root(ev.buf, { 'moon.mod.json' }),
+          }))
+        end
+      })
+    end
   end
 }


### PR DESCRIPTION
When setting up the language server it can be important for the user to be able to provide both `capabilities` and an `on_attach` function for good integration. This adds this support while also adding the ability for the user to disable the LSP integration