### PR TITLE
feat(test): add neotest adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,22 @@ the MoonBit language.
   },
 }
 ```
+## neotest
+
+`moonbit.nvim` provides a [neotest](https://github.com/nvim-neotest/neotest) adapter, example config using `lazy.nvim`
+
+```lua
+{
+  "nvim-neotest/neotest",
+  depedencies = {
+    "moonbit-community/moonbit.nvim",
+  },
+  config = function()
+    require("neotest").setup({
+      adapters = {
+        require("neotest-moonbit"),
+      },
+    })
+  end,
+}
+```

--- a/lua/neotest-moonbit/init.lua
+++ b/lua/neotest-moonbit/init.lua
@@ -1,0 +1,257 @@
+local lib = require("neotest.lib")
+local types = require("neotest.types")
+local logger = require("neotest.logging")
+
+local jsonlist = require("neotest-moonbit.json")
+
+local joinpath = vim.fs.joinpath
+local basename = vim.fs.basename
+
+local filetype = require("plenary.filetype")
+if filetype.detect_from_extension("x.mbt") == "" then
+  filetype.add_table({ extension = { mbt = "moonbit" } })
+end
+
+--- @class Adapter : neotest.Adapter
+local M = {}
+
+local MOON_MOD_JSON = "moon.mod.json"
+local MOON_PKG_JSON = "moon.pkg.json"
+
+M.Adapter = { name = "neotest-moonbit" }
+
+---Find the project root directory given a current directory to work from.
+---Should no root be found, the adapter can still be used in a non-project context if a test file matches.
+---@async
+---@param dir string @Directory to treat as cwd
+---@return string | nil @Absolute root dir of test suite
+function M.Adapter.root(dir)
+  -- we want to ensure we are sitting at project root
+  if dir == lib.files.match_root_pattern(MOON_MOD_JSON)(dir) then
+    return dir
+  end
+  return nil
+end
+
+local function readJSON(path)
+  local f, err = io.open(path, "r"):read("*a")
+  if err then
+    logger.error(err)
+    return nil
+  end
+  local ok, json = pcall(vim.json.decode, f)
+  if not ok then
+    logger.error("Failed to parse " .. path)
+    return nil
+  end
+  return json
+end
+
+---Filter directories when searching for test files
+---@async
+---@param name string Name of directory
+---@param rel_path string Path to directory, relative to root
+---@param root string Root directory of project
+---@return boolean
+function M.Adapter.filter_dir(name, rel_path, root)
+  -- parse moon.mod.json source field
+  local moon_mod_path = joinpath(root, MOON_MOD_JSON)
+  local moon_mod_json = readJSON(moon_mod_path)
+  if not moon_mod_json then
+    return false
+  end
+
+  local source = moon_mod_json.source or "src"
+
+  if source == rel_path then
+    return true
+  end
+  if not vim.startswith(rel_path, source) then
+    return false
+  end
+
+  -- XXX: assuming rel_path is a package path
+  -- let's check if this is a main package or not
+  -- at the time of writing (2024-10-28), main package can't run tests.
+
+  local moon_pkg_path = joinpath(rel_path, MOON_PKG_JSON)
+  local moon_pkg_json = readJSON(moon_pkg_path)
+  if not moon_pkg_json then
+    return false
+  end
+  return not moon_pkg_json["is-main"]
+end
+
+---@async
+---@param file_path string
+---@return boolean
+function M.Adapter.is_test_file(file_path)
+  -- packages with `is-main = false` are all valid test files
+  -- which is checked in `filter_dir`
+  return vim.endswith(file_path, ".mbt")
+end
+
+---Given a file path, parse all the tests within it.
+---@async
+---@param file_path string Absolute file path
+---@return neotest.Tree | nil
+function M.Adapter.discover_positions(file_path)
+  local query = [[
+    (test_definition
+      (string_literal
+        (string_fragment
+          (unescaped_string_fragment) @test.name)))
+      @test.definition
+    ]]
+  local tree = lib.treesitter.parse_positions(file_path, query, {})
+  for i, child in ipairs(tree:children()) do
+    local id = child:data().id
+    -- currently moonbit run specific test using their test index in a file
+    local splitted_id = vim.fn.split(id, "::")
+    child:data().id = splitted_id[1] .. "::" .. tostring(i - 1)
+  end
+  return tree
+end
+
+---@param args neotest.RunArgs
+---@return nil | neotest.RunSpec | neotest.RunSpec[]
+function M.Adapter.build_spec(args)
+  --- The tree object, describing the AST-detected tests and their positions.
+  --- @type neotest.Tree
+  local tree = args.tree
+
+  if not tree then
+    logger.error("Unexpectedly did not receive a neotest.Tree.")
+    return
+  end
+
+  --- The position object, describing the current directory, file or test.
+  --- @type neotest.Position
+  local pos = tree:data()
+
+  -- NOTE: assume cwd to be our project root for now to simplify things
+  local root = vim.uv.cwd()
+  local moon_mod_path = joinpath(root, MOON_MOD_JSON)
+  local moon_mod_json = readJSON(moon_mod_path)
+  if not moon_mod_json then
+    logger.error("probably not a moonbit project root.")
+    return nil
+  end
+
+  local src_path = joinpath(root, moon_mod_json.source or "src")
+  local rel_path = pos.path:sub(#src_path + 2)
+  local filename = basename(rel_path)
+  local pkg_name = rel_path:sub(0, -(#filename + 2))
+
+  if pos.type == "test" then
+    local splitted_pos_id = vim.fn.split(pos.id, "::")
+    local test_idx = splitted_pos_id[#splitted_pos_id]
+
+    return {
+      command = { "moon", "test", "--test-failure-json", "-p", pkg_name, "-f", filename, "-i", test_idx },
+      cwd = root,
+      context = {
+        kind = "test",
+        test_idx = test_idx,
+        path = pos.path,
+      },
+    }
+  elseif pos.type == "file" then
+    return {
+      command = { "moon", "test", "--test-failure-json", "-p", pkg_name, "-f", filename },
+      cwd = root,
+      context = {
+        kind = "file",
+        path = pos.path,
+      },
+    }
+  elseif pos.type == "dir" then
+    return {
+      command = { "moon", "test", "--test-failure-json" },
+      cwd = root,
+      context = {
+        kind = "dir",
+        path = pos.path,
+        pkg_name = pkg_name,
+      },
+    }
+  else
+    logger.error("unknown pos.type " .. pos.type)
+  end
+end
+
+---@param tree neotest.Tree
+---@param results table<string, neotest.Result>
+---@return table<string, neotest.Result>
+local function build_results(tree, results)
+  -- traverse the nested tree, and put the result
+  results[tree:data().id] = { status = types.ResultStatus.passed }
+  for _, child in pairs(tree:children()) do
+    build_results(child, results)
+  end
+  return results
+end
+
+---@async
+---@param spec neotest.RunSpec
+---@param result neotest.StrategyResult
+---@param tree neotest.Tree
+---@return table<string, neotest.Result>
+function M.Adapter.results(spec, result, tree)
+  -- vim.print("=================== results")
+  -- vim.print(vim.inspect(spec))
+  -- vim.print(vim.inspect(result))
+  -- vim.print(vim.inspect(tree:data()))
+  -- vim.print("id: " .. tree:data().id)
+  -- if result.code == 0 then
+  --   return { [tree:data().id] = { status = types.ResultStatus.passed } }
+  -- end
+  local results = build_results(tree, {})
+
+  if result.code == 0 then
+    return results
+  end
+
+  local output, err = io.open(result.output, "r"):read("*a")
+  if err then
+    logger.error(err)
+    return {}
+  end
+
+  -- print("output")
+  -- print(vim.inspect(output))
+
+  local function build_id(context, res)
+    if context.kind ~= "dir" then
+      return context.path .. "::" .. res.index
+    end
+    -- for `dir` kind, we want extract filename from res.message
+    local filename = vim.fn.split(res.message, ":")[2]
+    filename = filename:sub(2)
+    return filename .. "::" .. res.index
+  end
+
+  local failure_jsons = jsonlist.decode_from_string(output)
+  -- vim.print("failure_jsons: " .. #failure_jsons)
+  -- vim.print(vim.inspect(failure_jsons))
+  for _, failed in pairs(failure_jsons) do
+    -- parse range and put it into neotest.Result
+    local id = build_id(spec.context, failed)
+    local line = failed.message:match(spec.context.path .. ":(%d+):")
+    local message = failed.message:match("`(.+)`$") or "Test failed"
+    results[id] = {
+      status = types.ResultStatus.failed,
+      output = result.output,
+      errors = {
+        {
+          message = message,
+          line = tonumber(line) - 1,
+        },
+      },
+    }
+  end
+  -- vim.print(vim.inspect(results))
+  return results
+end
+
+return M.Adapter

--- a/lua/neotest-moonbit/init.lua
+++ b/lua/neotest-moonbit/init.lua
@@ -63,11 +63,13 @@ function M.Adapter.filter_dir(name, rel_path, root)
 
   local source = moon_mod_json.source or "src"
 
-  if source == rel_path then
-    return true
-  end
-  if not vim.startswith(rel_path, source) then
-    return false
+  if source ~= nil then
+    if source == rel_path then
+      return true
+    end
+    if not vim.startswith(rel_path, source) then
+      return false
+    end
   end
 
   -- XXX: assuming rel_path is a package path

--- a/lua/neotest-moonbit/init.lua
+++ b/lua/neotest-moonbit/init.lua
@@ -200,14 +200,6 @@ end
 ---@param tree neotest.Tree
 ---@return table<string, neotest.Result>
 function M.Adapter.results(spec, result, tree)
-  -- vim.print("=================== results")
-  -- vim.print(vim.inspect(spec))
-  -- vim.print(vim.inspect(result))
-  -- vim.print(vim.inspect(tree:data()))
-  -- vim.print("id: " .. tree:data().id)
-  -- if result.code == 0 then
-  --   return { [tree:data().id] = { status = types.ResultStatus.passed } }
-  -- end
   local results = build_results(tree, {})
 
   if result.code == 0 then
@@ -219,9 +211,6 @@ function M.Adapter.results(spec, result, tree)
     logger.error(err)
     return {}
   end
-
-  -- print("output")
-  -- print(vim.inspect(output))
 
   local function get_test_filepath(context, failed)
     if context.kind ~= "dir" then
@@ -242,8 +231,6 @@ function M.Adapter.results(spec, result, tree)
   end
 
   local failure_jsons = jsonlist.decode_from_string(output)
-  -- vim.print("failure_jsons: " .. #failure_jsons)
-  -- vim.print(vim.inspect(failure_jsons))
 
   for _, failed in pairs(failure_jsons) do
     -- parse range and put it into neotest.Result
@@ -261,7 +248,6 @@ function M.Adapter.results(spec, result, tree)
       },
     }
   end
-  -- vim.print(vim.inspect(results))
   return results
 end
 

--- a/lua/neotest-moonbit/init.lua
+++ b/lua/neotest-moonbit/init.lua
@@ -61,7 +61,7 @@ function M.Adapter.filter_dir(name, rel_path, root)
     return false
   end
 
-  local source = moon_mod_json.source or "src"
+  local source = moon_mod_json.source
 
   if source ~= nil then
     if source == rel_path then

--- a/lua/neotest-moonbit/json.lua
+++ b/lua/neotest-moonbit/json.lua
@@ -1,0 +1,49 @@
+--- From: neotest-golang
+--- JSON processing helpers.
+
+local logger = require("neotest.logging")
+
+local M = {}
+
+--- Decode JSON from a table of strings into a table of objects.
+--- @param tbl table
+--- @param construct_invalid boolean
+--- @return table
+function M.decode_from_table(tbl, construct_invalid)
+  local jsonlines = {}
+  for _, line in ipairs(tbl) do
+    if string.match(line, "^%s*{") then -- must start with the `{` character
+      local status, json_data = pcall(vim.fn.json_decode, line)
+      if status then
+        table.insert(jsonlines, json_data)
+      else
+        -- NOTE: this can be hit because of "Vim:E474: Unidentified byte: ..."
+        logger.warn("Failed to decode JSON line: " .. line)
+      end
+    else
+      logger.debug("Not valid JSON:", line)
+      if construct_invalid then
+        -- this is for example errors from stderr, when there is a compilation error
+        table.insert(jsonlines, { Action = "output", Output = line })
+      end
+    end
+  end
+  return jsonlines
+end
+
+--- Decode JSON from a string into a table of objects.
+--- @param str string
+--- @return table
+function M.decode_from_string(str)
+  -- Split the input into separate JSON objects
+  local tbl = {}
+  for line in str:gmatch("[^\r\n]+") do
+    line = line:gsub("^\27%[J", "", 1)
+    if line:match("^%s*{") then
+      table.insert(tbl, line)
+    end
+  end
+  return M.decode_from_table(tbl, false)
+end
+
+return M


### PR DESCRIPTION
This PR adds a [neotest](https://github.com/nvim-neotest/neotest) adapter.

Currently supports running individual tests, running all tests in a file, running all tests in a project.
Test results parsing is kinda hacky though.

Usage, using `lazy.nvim`
```lua
{
  "nvim-neotest/neotest",
  depedencies = { "moonbit-community/moonbit.nvim" },
  opts = {
    adapters = {
      ["neotest-moonbit"] = {},
    },
  },
}
```

Not sure if this fit the scope of this plugin though.