### PR TITLE
docs(readme): recommend the `opts`-based `neotest` setup approach

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,9 @@ the MoonBit language.
   depedencies = {
     "moonbit-community/moonbit.nvim",
   },
-  config = function()
-    require("neotest").setup({
-      adapters = {
-        require("neotest-moonbit"),
-      },
-    })
+  opts = function(_, opts)
+    if not opts.adapters then opts.adapters = {} end
+    table.insert(opts.adapters, require("neotest-moonbit"))
   end,
 }
 ```

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ the MoonBit language.
   depedencies = {
     "moonbit-community/moonbit.nvim",
   },
+  -- Using opts instead of config maximizes composability of overrides.
+  -- See: https://github.com/folke/lazy.nvim/discussions/1185#discussioncomment-7579598
   opts = function(_, opts)
     if not opts.adapters then opts.adapters = {} end
     table.insert(opts.adapters, require("neotest-moonbit"))


### PR DESCRIPTION
Using `opts` instead of `config` maximizes composability of overrides, as elaborated in this comment:

- https://github.com/folke/lazy.nvim/discussions/1185#discussioncomment-7579598

Tested locally with the very override without any issues.