### PR TITLE
feat: add update hook

### DIFF
--- a/lua/moonbit.lua
+++ b/lua/moonbit.lua
@@ -5,16 +5,15 @@ end
 return {
   setup = function(opts)
     local treesitter_opts = opts.treesitter or {}
-    local has_treesitter = pcall(require, 'nvim-treesitter.parsers')
     local enabled = treesitter_opts.enabled or true
-    if has_treesitter and enabled then
+    if enabled then
       require 'moonbit.treesitter'.setup(treesitter_opts)
     end
 
-    -- add plenary filetype 
+    -- add plenary filetype
     local has_plenary = pcall(require, "plenary")
     if has_plenary then
-        require("plenary.filetype").add_file("moonbit")
+      require("plenary.filetype").add_file("moonbit")
     end
 
     if opts.lsp ~= false then

--- a/lua/moonbit/treesitter.lua
+++ b/lua/moonbit/treesitter.lua
@@ -1,23 +1,50 @@
-local install_info = {
+local install_infos = {
   ['moonbit'] = {
     url = 'https://github.com/moonbitlang/tree-sitter-moonbit',
+    revision = '05bb5dbbe9b3b80c74113b791883fa2b85f0e14e',
     files = { 'src/parser.c', 'src/scanner.c' },
     branch = 'main',
   },
 }
 
+local function get_installed_revision(utils, configs, lang)
+  local lang_file = utils.join_path(configs.get_parser_info_dir(), lang .. ".revision")
+  if vim.fn.filereadable(lang_file) == 1 then
+    return vim.fn.readfile(lang_file)[1]
+  end
+end
+
+local function needs_update(utils, configs, lang)
+  local installed_revision = get_installed_revision(utils, configs, lang)
+  if not installed_revision then
+    return true
+  end
+  local info = install_infos[lang]
+  return installed_revision ~= info.revision
+end
+
 return {
-  setup = function (opts)
+  setup = function(opts)
+    local auto_install = opts.auto_install or true
     local has_treesitter, parsers = pcall(require, 'nvim-treesitter.parsers')
     if not has_treesitter then return end
+    local utils = require "nvim-treesitter.utils"
+    local configs = require "nvim-treesitter.configs"
+    local install = require "nvim-treesitter.install"
+    local update = install.update {}
 
-    for filetype, install_info in pairs(install_info) do
-      local opts = opts[filetype] or {}
-      local enabled = opts.enabled or true
+    for filetype, install_info in pairs(install_infos) do
+      local o = opts[filetype] or {}
+      local enabled = o.enabled or true
       if enabled then
-        opts.install_info = opts.install_info or install_info
-        opts.filetype = opts.filetype or filetype
-        parsers.get_parser_configs()[filetype] = opts
+        o.install_info = o.install_info or install_info
+        o.filetype = o.filetype or filetype
+        parsers.get_parser_configs()[filetype] = o
+        if auto_install then
+          if not parsers.has_parser(filetype) or needs_update(utils, configs, filetype) then
+            update(filetype)
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
See #17.

This fails since the build hooks is run before config, therefore the parser information is not registered to TS.

<img width="815" alt="image" src="https://github.com/user-attachments/assets/531feeca-c555-4f95-9c1f-ddfe8bcb982b">

Two solutions in my mind right now:

1. Upstream the tree-sitter parser to [nvim-treesitter](https://github.com/nvim-treesitter/nvim-treesitter), so that users get updates from there.
2. Assume everyone would use the TS parser, and I setup moonbit parser anyway inside the `update` hook

How to test:

1. Change the settings to the following:

  ```lua
  {
    "moonbit-community/moonbit.nvim",
    ft = { "moonbit" },
    branch = 'update',
    build = function()
      require('moonbit').update()
    end,
    opts = {}
  }
  ```

2. Open `Lazy` (or other package manager) to first clean/uninstall then reinstall, see if the parser gets automatically installed