### PR TITLE
feat(plenary): add plenary.filetype

### DIFF
--- a/data/plenary/filetypes/moonbit.lua
+++ b/data/plenary/filetypes/moonbit.lua
@@ -1,0 +1,5 @@
+return {
+	extension = {
+		["mbt"] = "moonbit",
+	},
+}

--- a/lua/moonbit.lua
+++ b/lua/moonbit.lua
@@ -11,6 +11,12 @@ return {
       require 'moonbit.treesitter'.setup(treesitter_opts)
     end
 
+    -- add plenary filetype 
+    local has_plenary = pcall(require, "plenary")
+    if has_plenary then
+        require("plenary.filetype").add_file("moonbit")
+    end
+
     if opts.lsp ~= false then
       vim.api.nvim_create_autocmd('FileType', {
         pattern = 'moonbit',


### PR DESCRIPTION
as title, some plugins like https://github.com/yetone/avante.nvim are using https://github.com/nvim-lua/plenary.nvim to detect filetype, this will auto register an `moonbit` filetype for `.mbt`.

example:
![image](https://github.com/user-attachments/assets/30ac690d-1fd0-4644-bece-6213b50489c6)

(this icon is set in mini.icons by myself)

maybe add some doc about plenary dependence, depends on you.

by the way, the screenshot are broken, maybe should fix(