### PR TITLE
fix: subscribe json & find lsp-server.js

### DIFF
--- a/lua/moonbit.lua
+++ b/lua/moonbit.lua
@@ -207,8 +207,8 @@ return {
         group = moonbit_lsp_group,
         callback = on_attach,
       })
-      vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
-        pattern = { '*.mbt', 'moon.pkg.json', 'moon.mod.json', },
+      vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile' }, {
+        pattern = { 'moon.pkg.json', 'moon.mod.json', },
         group = moonbit_lsp_group,
         callback = on_attach,
       })

--- a/lua/moonbit.lua
+++ b/lua/moonbit.lua
@@ -107,6 +107,23 @@ end
 
 local path_sep = package.config:sub(1, 1)
 
+---@return string
+local function find_lsp_server()
+  local moon_home = vim.env["MOON_HOME"]
+  if moon_home == nil then
+    local home = vim.env["HOME"]
+    if home == nil then
+      home = '~'
+    end
+    moon_home = home .. path_sep .. '.moon'
+  end
+  local lsp_server_path = vim.fn.resolve(moon_home .. path_sep .. 'bin' .. path_sep .. 'lsp-server.js')
+  if vim.fn.executable(lsp_server_path) ~= 0 then
+    return lsp_server_path
+  end
+  return 'moonbit-lsp'
+end
+
 return {
   api = {
     toggle_multiline_string_operatorfunc = function(type)
@@ -129,29 +146,12 @@ return {
       require("plenary.filetype").add_file("moonbit")
     end
 
-    ---@return string
-    local function find_lsp_cmd()
-      local moon_home = vim.env["MOON_HOME"]
-      if moon_home == nil then
-        local home = vim.env["HOME"]
-        if home == nil then
-          home = '~'
-        end
-        moon_home = home .. path_sep .. '.moon'
-      end
-      local lsp_server_path = vim.fn.resolve(moon_home .. path_sep .. 'bin' .. path_sep .. 'lsp-server.js')
-      if vim.fn.executable(lsp_server_path) ~= 0 then
-        return lsp_server_path
-      end
-      return 'moonbit-lsp'
-    end
-
     if opts.lsp ~= false then
       local function on_attach(ev)
         setup_toggle_multiline_string(ev.buf)
         vim.lsp.start(vim.tbl_deep_extend("keep", opts.lsp or {}, {
           name = 'moonbit-lsp',
-          cmd = { find_lsp_cmd() },
+          cmd = { find_lsp_server() },
           root_dir = vim.fs.root(ev.buf, { 'moon.mod.json' }),
           commands = {
             ['moonbit-lsp/test'] = function(command, ctx)

--- a/lua/moonbit.lua
+++ b/lua/moonbit.lua
@@ -128,61 +128,70 @@ return {
     end
 
     if opts.lsp ~= false then
+      local function on_attach(ev)
+        setup_toggle_multiline_string(ev.buf)
+        vim.lsp.start(vim.tbl_deep_extend("keep", opts.lsp or {}, {
+          name = 'moonbit-lsp',
+          cmd = { 'moonbit-lsp' },
+          root_dir = vim.fs.root(ev.buf, { 'moon.mod.json' }),
+          commands = {
+            ['moonbit-lsp/test'] = function(command, ctx)
+              local arguments = command.arguments[1]
+              local stdout = vim.uv.new_pipe()
+              local stderr = vim.uv.new_pipe()
+              local args = {
+                'test',
+                '--target=' .. arguments.backend,
+                '-p',
+                arguments.pkgPath,
+                '-f',
+                arguments.fileName,
+                '-i',
+                tostring(arguments.index),
+              }
+              if arguments.update then
+                table.insert(args, '-u')
+              end
+              local handle, pid = vim.uv.spawn('moon', {
+                args = args,
+                cwd = arguments.cwdUri:sub(7, -1),
+                stdio = { nil, stdout, stderr }
+              }, function()
+                stdout:close()
+                stderr:close()
+                vim.schedule(function()
+                  vim.api.nvim_buf_call(ev.buf, function()
+                    vim.cmd [[edit]]
+                  end)
+                end)
+                -- print('exit code', code)
+              end)
+              vim.uv.read_start(stdout, function(err, data)
+                assert(not err, err)
+                if not data then
+                  return
+                end
+                local trimmed = trim(data)
+                if trimmed ~= "" then
+                  print(trimmed)
+                end
+              end)
+            end,
+          },
+        }))
+      end
+
+      local moonbit_lsp_group = vim.api.nvim_create_augroup('MoonBitLsp', { clear = true });
+
       vim.api.nvim_create_autocmd('FileType', {
         pattern = 'moonbit',
-        group = vim.api.nvim_create_augroup("moonbit_lsp", { clear = true }),
-        callback = function(ev)
-          setup_toggle_multiline_string(ev.buf)
-          vim.lsp.start(vim.tbl_deep_extend("keep", opts.lsp or {}, {
-            name = 'moonbit-lsp',
-            cmd = { 'moonbit-lsp' },
-            root_dir = vim.fs.root(ev.buf, { 'moon.mod.json' }),
-            commands = {
-              ['moonbit-lsp/test'] = function(command, ctx)
-                local arguments = command.arguments[1]
-                local stdout = vim.uv.new_pipe()
-                local stderr = vim.uv.new_pipe()
-                local args = {
-                  'test',
-                  '--target=' .. arguments.backend,
-                  '-p',
-                  arguments.pkgPath,
-                  '-f',
-                  arguments.fileName,
-                  '-i',
-                  tostring(arguments.index),
-                }
-                if arguments.update then
-                  table.insert(args, '-u')
-                end
-                local handle, pid = vim.uv.spawn('moon', {
-                  args = args,
-                  cwd = arguments.cwdUri:sub(7, -1),
-                  stdio = { nil, stdout, stderr }
-                }, function()
-                  stdout:close()
-                  stderr:close()
-                  vim.schedule(function()
-                    vim.api.nvim_buf_call(ev.buf, function()
-                      vim.cmd [[edit]]
-                    end)
-                  end)
-                  -- print('exit code', code)
-                end)
-                vim.uv.read_start(stdout, function(err, data)
-                  assert(not err, err)
-                  if not data then
-                    return
-                  end
-                  local trimmed = trim(data)
-                  if trimmed ~= "" then
-                    print(trimmed)
-                  end
-                end)
-              end,
-            },
-          }))
-        end,
+        group = moonbit_lsp_group,
+        callback = on_attach,
+      })
+      vim.api.nvim_create_autocmd({ 'BufEnter', 'BufWinEnter' }, {
+        pattern = { '*.mbt', 'moon.pkg.json', 'moon.mod.json', },
+        group = moonbit_lsp_group,
+        callback = on_attach,
       })
     end
   end

--- a/lua/moonbit.lua
+++ b/lua/moonbit.lua
@@ -105,6 +105,8 @@ local function setup_toggle_multiline_string(buffer)
   })
 end
 
+local path_sep = package.config:sub(1, 1)
+
 return {
   api = {
     toggle_multiline_string_operatorfunc = function(type)
@@ -127,12 +129,29 @@ return {
       require("plenary.filetype").add_file("moonbit")
     end
 
+    ---@return string
+    local function find_lsp_cmd()
+      local moon_home = vim.env["MOON_HOME"]
+      if moon_home == nil then
+        local home = vim.env["HOME"]
+        if home == nil then
+          home = '~'
+        end
+        moon_home = home .. path_sep .. '.moon'
+      end
+      local lsp_server_path = vim.fn.resolve(moon_home .. path_sep .. 'bin' .. path_sep .. 'lsp-server.js')
+      if vim.fn.executable(lsp_server_path) ~= 0 then
+        return lsp_server_path
+      end
+      return 'moonbit-lsp'
+    end
+
     if opts.lsp ~= false then
       local function on_attach(ev)
         setup_toggle_multiline_string(ev.buf)
         vim.lsp.start(vim.tbl_deep_extend("keep", opts.lsp or {}, {
           name = 'moonbit-lsp',
-          cmd = { 'moonbit-lsp' },
+          cmd = { find_lsp_cmd() },
           root_dir = vim.fs.root(ev.buf, { 'moon.mod.json' }),
           commands = {
             ['moonbit-lsp/test'] = function(command, ctx)
@@ -181,7 +200,7 @@ return {
         }))
       end
 
-      local moonbit_lsp_group = vim.api.nvim_create_augroup('MoonBitLsp', { clear = true });
+      local moonbit_lsp_group = vim.api.nvim_create_augroup('moonbit.lsp', { clear = true });
 
       vim.api.nvim_create_autocmd('FileType', {
         pattern = 'moonbit',


### PR DESCRIPTION
This PR subscribe to opened `moon.pkg.json` and `moon.mod.json`, so that changes in these two buffer can be picked by the lsp, and these two files can have diagnostics.

Also, this PR add support to the `lsp-server.js` distributed along with the moonbit installation.