### PR TITLE
feat: conceal

### DIFF
--- a/lua/moonbit/editor.lua
+++ b/lua/moonbit/editor.lua
@@ -112,5 +112,6 @@ return {
   },
   on_attach = function(bufnr)
     setup_toggle_multiline_string(bufnr)
+    vim.cmd [[syntax match MoonBitBlockLine "///| "ms=s+3 conceal cchar= ]]
   end
 }

--- a/queries/moonbit/highlights.scm
+++ b/queries/moonbit/highlights.scm
@@ -237,6 +237,9 @@
 ;; Comments
 
 (comment) @comment @spell
+(((comment) @comment @conceal)
+ (#match? @comment "^///\\|$")
+ (#set! conceal_lines ""))
 (docstring) @comment.documentation @spell
 
 ;; Errors


### PR DESCRIPTION
This PR add conceal capability to complete hides away the `///|` block line.

This option is not enable by default. To use it, please execute the following Ex command:

```vimscript
:set conceallevel=2
```