### PR TITLE
[codex] Use moonbit-lsp binary

### DIFF
--- a/lua/moonbit/lsp.lua
+++ b/lua/moonbit/lsp.lua
@@ -1,6 +1,11 @@
 local path_sep = package.config:sub(1, 1)
 
 ---@return string
+local function lsp_server_executable_name()
+  return vim.fn.has('win32') == 1 and 'moonbit-lsp.exe' or 'moonbit-lsp'
+end
+
+---@return string
 local function find_lsp_server()
   local moon_home = vim.env["MOON_HOME"]
   if moon_home == nil then
@@ -10,7 +15,9 @@ local function find_lsp_server()
     end
     moon_home = home .. path_sep .. '.moon'
   end
-  local lsp_server_path = vim.fn.resolve(moon_home .. path_sep .. 'bin' .. path_sep .. 'lsp-server.js')
+  local lsp_server_path = vim.fn.resolve(
+    moon_home .. path_sep .. 'bin' .. path_sep .. lsp_server_executable_name()
+  )
   if vim.fn.executable(lsp_server_path) ~= 0 then
     return lsp_server_path
   end
@@ -313,11 +320,11 @@ end
 function M.on_attach(bufnr)
   if vim.lsp and vim.lsp.config then
     if vim.bo[bufnr].filetype ~= 'moonbit' then
-      vim.lsp.start({
-        cmd = { 'moonbit-lsp' },
+      vim.lsp.start(vim.tbl_deep_extend("keep", stored_config or {}, {
+        cmd = { find_lsp_server() },
         name = 'moonbit-lsp',
         root_dir = vim.fs.root(bufnr, { 'moon.mod.json' }),
-      })
+      }))
     end
     return
   end

--- a/tests/moonbit/lsp_spec.lua
+++ b/tests/moonbit/lsp_spec.lua
@@ -1,0 +1,73 @@
+local lsp = require('moonbit.lsp')
+local path_sep = package.config:sub(1, 1)
+local tmp_paths = {}
+
+local function mkdir(path)
+  assert(vim.fn.mkdir(path, 'p') == 1)
+end
+
+local function touch_executable(path)
+  assert(vim.fn.writefile({ '#!/bin/sh', 'exit 0' }, path) == 0)
+  assert(vim.fn.setfperm(path, 'rwxr-xr-x') == 1)
+end
+
+local function temp_moon_home(name)
+  local path = vim.fn.resolve(vim.fn.tempname()) .. '-' .. name
+  table.insert(tmp_paths, path)
+  return path
+end
+
+local function lsp_server_executable_name()
+  return vim.fn.has('win32') == 1 and 'moonbit-lsp.exe' or 'moonbit-lsp'
+end
+
+describe('lsp', function()
+  local original_moon_home
+
+  before_each(function()
+    original_moon_home = vim.env.MOON_HOME
+  end)
+
+  after_each(function()
+    vim.env.MOON_HOME = original_moon_home
+    for _, path in ipairs(tmp_paths) do
+      vim.fn.delete(path, 'rf')
+    end
+    tmp_paths = {}
+    if vim.lsp and vim.lsp.enable then
+      vim.lsp.enable('moonbit-lsp', false)
+    end
+  end)
+
+  it('prefers the moonbit-lsp binary from MOON_HOME', function()
+    if not (vim.lsp and vim.lsp.config) then
+      return
+    end
+
+    local moon_home = temp_moon_home('with-lsp')
+    local bin_dir = moon_home .. path_sep .. 'bin'
+    local lsp_server = bin_dir .. path_sep .. lsp_server_executable_name()
+    mkdir(bin_dir)
+    touch_executable(lsp_server)
+    touch_executable(bin_dir .. path_sep .. 'lsp-server.js')
+    vim.env.MOON_HOME = moon_home
+
+    lsp.setup({})
+
+    assert.are.same({ lsp_server }, vim.lsp.config['moonbit-lsp'].cmd)
+  end)
+
+  it('falls back to moonbit-lsp on PATH when MOON_HOME has no binary', function()
+    if not (vim.lsp and vim.lsp.config) then
+      return
+    end
+
+    local moon_home = temp_moon_home('empty')
+    mkdir(moon_home .. path_sep .. 'bin')
+    vim.env.MOON_HOME = moon_home
+
+    lsp.setup({})
+
+    assert.are.same({ 'moonbit-lsp' }, vim.lsp.config['moonbit-lsp'].cmd)
+  end)
+end)


### PR DESCRIPTION
## Summary

- Prefer `$MOON_HOME/bin/moonbit-lsp` over the legacy `$MOON_HOME/bin/lsp-server.js` when starting MoonBit LSP.
- Reuse the same LSP command resolution for non-`moonbit` buffers that are attached manually, such as `moon.pkg`.
- Add regression coverage for the LSP command selection path.

## Root Cause

The Neovim plugin was still probing for the old `lsp-server.js` entrypoint first. Users with a stale executable there could end up connected to the old language server, while the official VS Code extension now starts `moonbit-lsp`. When a user's generic LSP format-on-save hook hit that stale server, `:w` could fail until LSP was disabled.

## Validation

```sh
env NVIM_LOG_FILE=/private/tmp/moonbit-nvim-tests.log nvim --headless --noplugin -u tests/minimal_init.lua -c "PlenaryBustedDirectory tests/ {minimal_init = 'tests/minimal_init.lua'}"
```

All existing Plenary tests pass, including the new LSP command selection tests.